### PR TITLE
set up member view page

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@apollo/client": "^3.7.14",
     "@reduxjs/toolkit": "^1.9.5",
     "antd": "^5.6.1",
+    "dayjs": "^1.11.9",
     "graphql": "^16.6.0",
     "nodemon": "^2.0.22",
     "react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ export default function App() {
         <Route path="/member/:id" element={<MemberView />} />
 
         // 회원 정보 수정
-        <Route path="/member/update/:id" element={<MemberUpdate />} />
+        <Route path="/member" element={<MemberUpdate />} />
       </Routes>
     </div>
   )

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -32,8 +32,8 @@ const logOut: Menu = {
 
 const member: Menu = {
     key: "member",
-    link: "/member/list",
-    text: "회원목록"
+    link: "/member",
+    text: "회원정보"
 }
 
 const Navbar: React.FC = () => {

--- a/src/handlers/GraphQLErrorHandler.tsx
+++ b/src/handlers/GraphQLErrorHandler.tsx
@@ -47,4 +47,11 @@ export const handleGraphQLError = (err: ResponseError) => {
       removeCookieToken();
     }
   }
+
+  if (code === 'MEMBER_ID_NULL') {
+    alert('회원정보가 없습니다. 다시 로그인 해주세요.');
+    store.dispatch(DELETE_TOKEN);
+    removeCookieToken();
+    location.href='/login'
+  }
 }

--- a/src/routes/login/LogIn.tsx
+++ b/src/routes/login/LogIn.tsx
@@ -31,7 +31,7 @@ export default function LogIn() {
     const navigate = useNavigate();
 
     useEffect(() => {
-        if (data) {console.log(data);
+        if (data) {
             const response = JSON.parse(data.login);
             if (response.ok) {
                 setFailed(false);

--- a/src/routes/member/MemberUpdate.tsx
+++ b/src/routes/member/MemberUpdate.tsx
@@ -1,17 +1,21 @@
 import { gql, useMutation, useQuery } from "@apollo/client";
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
 import { Member } from "../../interfaces/Member";
-import ButtonLink from "../../components/common/ButtonLink";
-
+import { useForm } from "antd/es/form/Form";
+import { Button, DatePicker, Form, Input, Select } from "antd";
+import styles from "../../styles/routes/member/MemberUpdate.module.scss"
+import dayjs from "dayjs";
+import { useApolloClient } from "@apollo/client";
 
 const GET_MEMBER = gql`
-    query Member($memberId: Int!) {
-        member(id: $memberId) {
+    query Member {
+        member {
             id
             username
             password
             fullName
+            gender
+            dateOfBirth
             createdAt
             updatedAt
         }
@@ -19,12 +23,14 @@ const GET_MEMBER = gql`
 `;
 
 const UPDATE_MEMBER = gql`
-    mutation UpdateMember($updateMemberId: Int!, $password: String, $fullName: String) {
-        updateMember(id: $updateMemberId, password: $password, fullName: $fullName) {
+    mutation UpdateMember($id: Int!, $password: String, $fullName: String, $gender: String, $dateOfBirth: Date) {
+        updateMember(id: $id, password: $password, fullName: $fullName, gender: $gender, dateOfBirth: $dateOfBirth) {
             id
             username
             password
             fullName
+            gender
+            dateOfBirth
             createdAt
             updatedAt
         }
@@ -32,87 +38,227 @@ const UPDATE_MEMBER = gql`
 `;
 
 export default function MemberUpdate() {
-    const { id } = useParams();
+    const [form] = useForm();
     const [member, setMember] = useState<Member>();
-    const [updatedMember, setUpdatedMember] = useState<Member>({
-        id: 0,
-        username: "",
-        password: "",
-        fullName: ""
-    });
+    const client = useApolloClient();
 
-    const { data:getMemberData, loading: getMemberLoading } = useQuery(GET_MEMBER, {
-        variables: {memberId: Number(id)}
-    });
+    const worker = {
+        ...member,
+        dateOfBirth: dayjs(member?.dateOfBirth),
+        password: '********',
+        confirmPassword: '********'
+    };
+
+    const { data:getMemberData, loading: getMemberLoading } = useQuery(GET_MEMBER);
 
     const [updateMember, { data: updateMemberData }] = useMutation(UPDATE_MEMBER);
 
     useEffect(() => {
-        if (getMemberData !== undefined) {
+        if (getMemberData) {
             setMember(getMemberData.member);
-            setUpdatedMember(getMemberData.member);
         }
     }, [getMemberData])
 
-    const onNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setUpdatedMember((current) => {
-            return {...current, fullName: event.target.value}
-        });
-    }
-
-    const onUsernameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setUpdatedMember((current) => {
-            return {...current, username: event.target.value}
-        });
-    }
-
-    const onPasswordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setUpdatedMember((current) => {
-            return {...current, password: event.target.value}
-        });
-    }
-
     useEffect(() => {
-        if (updateMemberData !== undefined) {
-            location.href = "/member/"+updateMemberData.updateMember.id;
+        if (updateMemberData) {
+            setMember(updateMemberData.updateMember);
         }
     }, [updateMemberData])
 
-    const confirmupdateMember = () => {
-        if (updatedMember === member) {
-            alert("수정사항을 입력하여 주세요.");
-            return false;
+    const validatePassword = (_: object, password: string) => {
+
+        if (!password) {
+            form.setFieldValue('password', '********')
+            return Promise.resolve();
         }
-        if (window.confirm("회원 정보를 수정하시겠습니까?") && member !== undefined) {
-            updateMember({variables:{updateMemberId: updatedMember.id, password: updatedMember.password, fullName: updatedMember.fullName}});
+
+        if (password?.length < 8 || password?.length > 20) {
+            return Promise.reject(new Error('비밀번호는는 8자 이상 20자 이하여야 합니다.'))
+        }
+
+        const regExp = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/;
+
+        if (password !== '********') {
+            if (!regExp.test(password)) {
+                return Promise.reject(new Error('비밀번호는 영어, 숫자, 특수문자를 모두 포함하여야 합니다.'))
+            }
+        }
+
+        return Promise.resolve();
+    }
+
+    const validateConfirmPassword = (_: object, confirmPassword: string) => {
+
+        if (confirmPassword === '') {
+            form.setFieldValue('confirmPassword', '********');
+            confirmPassword = form.getFieldValue('confirmPassword');
+        }
+
+        const password = form.getFieldValue('password');
+        if (confirmPassword !== password) {
+            return Promise.reject(new Error('비밀번호가 일치하지 않습니다.'))
+        }
+        return Promise.resolve();
+    }
+
+    const handleUpdateMember = (data: Member) => {
+        const dateOfBirth = dayjs(data.dateOfBirth).format('YYYY-MM-DD');
+        if (data.fullName === member?.fullName 
+            && data.gender === member?.gender 
+            && dateOfBirth === String(member?.dateOfBirth) 
+            && (data.password === '********' || data.password === member?.password)) {
+                alert("수정사항을 입력하여 주세요.");
+                return false;
+        }
+
+        if (window.confirm("회원 정보를 수정하시겠습니까?") && member) {
+            const variables: Member = {id: member.id};
+            if (data.fullName !== member.fullName) variables.fullName = data.fullName;
+            if (data.gender !== member.gender) variables.gender = data.gender;
+            if (dateOfBirth !== String(member.dateOfBirth)) variables.dateOfBirth = data.dateOfBirth;
+            if (data.password !== '********' && data.password !== member.password) variables.password = data.password;
+            updateMember({variables: variables});
+            client.cache.evict({ id: `Member:${member.id}` });
         }
     }
 
+    const handleUpdateMemberFailed = (error: any) => {
+        console.log('[ERROR]', error);
+    }
 
     if (getMemberLoading || member === undefined) {
         return <></>;
     }
 
     return (
-        <div>
-            <table>
-                <tbody>
-                    <tr>
-                        <th>이름</th>
-                        <td><input type="text" value={updatedMember.fullName} onChange={onNameChange} /></td>
-                    </tr>
-                    <tr>
-                        <th>아이디</th>
-                        <td><input readOnly disabled type="text" value={updatedMember.username} onChange={onUsernameChange} /></td>
-                    </tr>
-                    <tr>
-                        <th>비밀번호</th>
-                        <td><input type="password" value={updatedMember.password} onChange={onPasswordChange} /></td>
-                    </tr>
-                </tbody>
-            </table>
-            <button onClick={confirmupdateMember}>완료</button>
-            <ButtonLink link={"/member/"+member.id} text="뒤로" />
+        <div className={styles.member_update_form_container}>
+            <div>
+                <h1>회원정보</h1>
+            </div>
+            <div className={styles.member_update_form}>
+                <Form 
+                    requiredMark={false} 
+                    form={form} 
+                    name="memberUpdateForm" 
+                    layout="vertical" 
+                    initialValues={worker} 
+                    onFinish={handleUpdateMember} 
+                    onFinishFailed={handleUpdateMemberFailed}
+                >
+                    <Form.Item 
+                        name="fullName" 
+                        label="이름" 
+                        rules={[
+                            {
+                                required: true,
+                                message: "이름은 필수입력 항목입니다."
+                            }
+                        ]}
+                        validateTrigger={['onBlur']}
+                    >
+                        <Input 
+                            placeholder="이름을 입력하여 주세요." 
+                            maxLength={10} 
+                        />
+                    </Form.Item>
+                    <Form.Item
+                        name="gender"
+                        label="성별"
+                        rules={[
+                            { 
+                                required: true, 
+                                message: '성별은 필수입력 항목입니다.' 
+                            }
+                        ]}
+                        validateTrigger={['onBlur']}
+                    >
+                        <Select
+                            placeholder="성별을 선택하여 주세요."
+                            options={[
+                                {value: "MALE", label: "남성"},
+                                {value: "FEMALE", label: "여성"},
+                                {value: "OTHER", label: "선택안함"},
+                            ]}
+                        />
+                    </Form.Item>
+                    <Form.Item 
+                        name="dateOfBirth" 
+                        label="생년월일" 
+                        rules={[
+                            {
+                                type: 'object' as const, 
+                                required: true, 
+                                message: '생년월일은 필수입력 항목입니다.'
+                            }
+                        ]}
+                    >
+                        <DatePicker 
+                            placeholder="생년월일을 선택하여 주세요." 
+                            className={styles.date_picker}
+                        />
+                    </Form.Item>
+                    <Form.Item
+                        name="username"
+                        label="아이디"
+                        rules={[
+                            {
+                                required: true
+                            }
+                        ]}
+                    >
+                        <Input
+                            readOnly
+                        />
+                    </Form.Item>
+                    <Form.Item 
+                        name="password" 
+                        label="비밀번호" 
+                        rules={[
+                            {
+                                validator: validatePassword,
+                            }
+                        ]}
+                        validateTrigger={['onBlur']}
+                    >
+                        <Input
+                            type="password"
+                            placeholder="비밀번호를 입력하여 주세요" 
+                            maxLength={20}
+                            onClick={() => {
+                                const password = form.getFieldValue('password');
+                                if (password === '********') {
+                                    form.setFieldValue('password', '');
+                                }
+                            }}
+                        />
+                    </Form.Item>
+                    <Form.Item 
+                        name="confirmPassword" 
+                        label="비밀번호 확인" 
+                        rules={[
+                            {
+                                validator: validateConfirmPassword,
+                            }
+                        ]}
+                        validateTrigger={['onBlur']}
+                    >
+                        <Input
+                            type="password"
+                            placeholder="비밀번호 확인을 입력하여 주세요" 
+                            maxLength={20}
+                            onClick={() => {
+                                const confirmPassword = form.getFieldValue('confirmPassword');
+                                if (confirmPassword === '********') {
+                                    form.setFieldValue('confirmPassword', '');
+                                }
+                            }}
+                        />
+                    </Form.Item>
+                    <Form.Item>
+                        <Button block size="large" type="primary" htmlType="submit">회원정보 수정</Button> 
+                    </Form.Item>
+                </Form>
+            </div>
         </div>
     );
 }

--- a/src/routes/signup/SignUp.tsx
+++ b/src/routes/signup/SignUp.tsx
@@ -81,7 +81,7 @@ export default function SignUp() {
     }
 
     const handleFinishFailed = (error: any) => {
-        console.log('[ERROR]' + error);
+        console.log('[ERROR]', error);
     }
     
     return (
@@ -176,7 +176,7 @@ export default function SignUp() {
                             },
                             {
                                 pattern: /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/,
-                                message: '비밀번호는 대소문자, 숫자, 특수문자를 모두 포함하여야 합니다.'
+                                message: '비밀번호는 영어, 숫자, 특수문자를 모두 포함하여야 합니다.'
                             },
                             {
                                 validator: validatePassword,

--- a/src/styles/routes/member/MemberUpdate.module.scss
+++ b/src/styles/routes/member/MemberUpdate.module.scss
@@ -1,0 +1,13 @@
+.member_update_form_container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    .member_update_form {
+        width: 25rem;
+    }
+}
+
+.date_picker {
+    width:100%;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,6 +1008,11 @@ dayjs@^1.11.1:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.8.tgz#4282f139c8c19dd6d0c7bd571e30c2d0ba7698ea"
   integrity sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==
 
+dayjs@^1.11.9:
+  version "1.11.9"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.9.tgz#9ca491933fadd0a60a2c19f6c237c03517d71d1a"
+  integrity sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"


### PR DESCRIPTION
### 관련 이슈
- #29 

### 수정 사항
- 회원정보 View& Update 페이지 생성 (View 페이지에서 바로 수정 가능)
- antd Form 이용
- dayjs 추가 (antd Form DatePicker에서 dayjs 사용)
- 회원정보 수정 시 cache에서 query 지우는 방식으로 해서 member data 최신으로 유지
- Member read는 id를 parameter로 보내지 않고 BE에서 token이용해 데이터 return
- Token에서 Member_id 없는경우 MEMBER_ID_NULL 코드의 GraphQLError return 
> 쿠키 및 리덕스의 token 제거 및 로그인 페이지로 redirect 
> 함수형 컴포넌트가 아닌 관계로 navigate가 사용 불가하여 location.href 로 구현했음 
> 추후 더 나은 방법 찾을 경우 수정 필요

### 기타 참고 사항
-
