### PR TITLE
set up encrypting password using crypto SHA256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@apollo/client": "^3.7.14",
     "@reduxjs/toolkit": "^1.9.5",
-    "@types/node": "^20.4.1",
     "antd": "^5.6.1",
     "crypto-js": "^4.1.1",
     "dayjs": "^1.11.9",
@@ -30,11 +29,13 @@
   },
   "devDependencies": {
     "@types/crypto-js": "4.1.1",
+    "@types/node": "^20.4.1",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
     "@vitejs/plugin-react": "^4.0.0",
+    "dotenv": "^16.3.1",
     "redux-devtools-extension": "^2.13.9",
     "typescript": "^5.0.2",
     "vite": "^4.3.2"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "@apollo/client": "^3.7.14",
     "@reduxjs/toolkit": "^1.9.5",
+    "@types/node": "^20.4.1",
     "antd": "^5.6.1",
+    "crypto-js": "^4.1.1",
     "dayjs": "^1.11.9",
     "graphql": "^16.6.0",
     "nodemon": "^2.0.22",
@@ -27,6 +29,7 @@
     "ts-node": "^10.9.1"
   },
   "devDependencies": {
+    "@types/crypto-js": "4.1.1",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "@typescript-eslint/eslint-plugin": "^5.57.1",

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { Menu } from "../../interfaces/Menu";
 import { Typography } from "antd";
 import { useDispatch, useSelector } from 'react-redux';
-import { removeCookieToken } from "../../cookie/Cookie";
+import { removeCookieToken, removeUsername } from "../../cookie/Cookie";
 import { DELETE_TOKEN } from "../../redux/Auth";
 import { useNavigate } from "react-router-dom";
 import logo from "../../images/skedulog_no_bg_underline.png";
@@ -78,6 +78,7 @@ const Navbar: React.FC = () => {
     const handleLogOut = () => {
         dispatch(DELETE_TOKEN());
         removeCookieToken();
+        removeUsername();
         client.cache.evict({ id: 'ROOT_QUERY', fieldName: 'member' })
         client.cache.gc();
         navigate('/');

--- a/src/cookie/Cookie.tsx
+++ b/src/cookie/Cookie.tsx
@@ -19,5 +19,20 @@ export const getCookieToken = () => {
 };
 
 export const removeCookieToken = () => {
-    return cookies.remove('refresh_token', { sameSite: 'strict', path: "/" })
+    return cookies.remove('refresh_token', { sameSite: 'strict', path: "/" });
+}
+
+export const setUsername = (username: string) => {
+    return cookies.set('username', username, {
+        sameSite: 'strict',
+        path: '/'
+    });
+}
+
+export const getUsername = () => {
+    return cookies.get('username');
+}
+
+export const removeUsername = () => {
+    return cookies.remove('username', { sameSite: 'strict', path: '/' });
 }

--- a/src/crypto/Crypto.tsx
+++ b/src/crypto/Crypto.tsx
@@ -1,0 +1,9 @@
+import crypto from "crypto-js";
+
+export const hashPassword = (username: string, password: string) => {
+    const algo = crypto.algo.SHA256.create();
+    algo.update(password);
+    algo.update(crypto.SHA256(username));
+
+    return algo.finalize().toString(crypto.enc.Base64);
+}

--- a/src/crypto/Crypto.tsx
+++ b/src/crypto/Crypto.tsx
@@ -4,6 +4,7 @@ export const hashPassword = (username: string, password: string) => {
     const algo = crypto.algo.SHA256.create();
     algo.update(password);
     algo.update(crypto.SHA256(username));
+    algo.update(crypto.SHA256(import.meta.env.VITE_CRYPTO_SECRET_KEY));
 
     return algo.finalize().toString(crypto.enc.Base64);
 }

--- a/src/routes/login/LogIn.tsx
+++ b/src/routes/login/LogIn.tsx
@@ -6,9 +6,10 @@ import { gql, useMutation } from "@apollo/client";
 import { useEffect, useState } from "react";
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';
-import { setRefreshToken } from "../../cookie/Cookie";
+import { setRefreshToken, setUsername } from "../../cookie/Cookie";
 import { SET_TOKEN } from "../../redux/Auth";
 import PageTitle from '../../components/pagetitle/PageTitle';
+import { hashPassword } from '../../crypto/Crypto';
 
 const LOG_IN = gql`
     mutation LogIn(
@@ -37,6 +38,7 @@ const LogIn: React.FC = () => {
             if (response.ok) {
                 setFailed(false);
                 setRefreshToken(response.tokens.refreshToken);
+                setUsername(form.getFieldValue('username'));
                 dispatch(SET_TOKEN(response.tokens.accessToken));
                 navigate('/');
             } else {
@@ -46,7 +48,7 @@ const LogIn: React.FC = () => {
     }, [data])
 
     const handleFinish = (data: LogInType) => {
-        logIn({ variables: { username: data.username, password: data.password }});
+        logIn({ variables: { username: data.username, password: hashPassword(data.username, data.password) }});
     }
 
     const handleFinishFailed = (error: any) => {

--- a/src/routes/member/MemberUpdate.tsx
+++ b/src/routes/member/MemberUpdate.tsx
@@ -11,6 +11,7 @@ import dayjs from "dayjs";
 import PageTitle from "../../components/pagetitle/PageTitle";
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
+import { hashPassword } from "../../crypto/Crypto";
 
 const GET_MEMBER = gql`
     query Member {
@@ -129,11 +130,18 @@ const MemberUpdate: React.FC = () => {
     }
 
     const handleUpdateMember = (data: Member) => {
+
+        if (!data.username || !data.password) {
+            throw new Error('username and password cannot be null');
+        }
+
         const dateOfBirth = dayjs(data.dateOfBirth).format('YYYY-MM-DD');
+        const hashedPassword = hashPassword(data.username ?? '', data.password ?? '');
+
         if (data.fullName === member?.fullName 
             && data.gender === member?.gender 
             && dateOfBirth === String(member?.dateOfBirth) 
-            && (data.password === '********' || data.password === member?.password)) {
+            && (data.password === '********' || hashedPassword === member?.password)) {
                 alert("수정사항을 입력하여 주세요.");
                 return false;
         }
@@ -143,7 +151,7 @@ const MemberUpdate: React.FC = () => {
             if (data.fullName !== member.fullName) variables.fullName = data.fullName;
             if (data.gender !== member.gender) variables.gender = data.gender;
             if (dateOfBirth !== String(member.dateOfBirth)) variables.dateOfBirth = data.dateOfBirth;
-            if (data.password !== '********' && data.password !== member.password) variables.password = data.password;
+            if (data.password !== '********' && hashedPassword !== member.password) variables.password = hashedPassword;
             updateMember({variables: variables});
             client.cache.evict({ id: `Member:${member.id}` });
         }

--- a/src/routes/passwordcheck/PasswordCheck.tsx
+++ b/src/routes/passwordcheck/PasswordCheck.tsx
@@ -6,6 +6,8 @@ import PageTitle from "../../components/pagetitle/PageTitle";
 import styles from "./PasswordCheck.module.scss";
 import { Button, Form, Input } from "antd";
 import { Member } from "../../interfaces/Member";
+import { hashPassword } from "../../crypto/Crypto";
+import { getUsername } from "../../cookie/Cookie";
 
 const PASSWORD_CHECK = gql`
     mutation PasswordCheck($password: String!) {
@@ -26,7 +28,7 @@ const PassWordCheck: React.FC = () => {
 
     const handleFinish = (data: Member) => {
         const password = data.password;
-        passwordCheck({ variables: { password: password } })
+        passwordCheck({ variables: { password: hashPassword(getUsername(), password ?? '') } })
     }
 
     const handleFinishFailed = (error: any) => {

--- a/src/routes/signup/SignUp.tsx
+++ b/src/routes/signup/SignUp.tsx
@@ -6,6 +6,7 @@ import { Member } from "../../interfaces/Member";
 import styles from "./SignUp.module.scss"
 import { useNavigate } from "react-router";
 import PageTitle from "../../components/pagetitle/PageTitle"
+import { hashPassword } from '../../crypto/Crypto';
 
 const SIGN_UP = gql`
     mutation SignUp(
@@ -92,7 +93,7 @@ const SignUp: React.FC = () => {
             createMember({
                 variables: { 
                     createMemberUsername: data.username, 
-                    createMemberPassword: data.password, 
+                    createMemberPassword: hashPassword(data.username ?? '', data.password ?? ''), 
                     createMemberFullName: data.fullName,
                     createMemberGender: data.gender,
                     createMemberDateOfBirth: data.dateOfBirth

--- a/yarn.lock
+++ b/yarn.lock
@@ -1059,6 +1059,11 @@ dom-align@^1.7.0:
   resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.12.4.tgz#3503992eb2a7cfcb2ed3b2a6d21e0b9c00d54511"
   integrity sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==
 
+dotenv@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
 electron-to-chromium@^1.4.284:
   version "1.4.387"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.387.tgz#9a93ef1bd01b5898436026401ea3cabb1dd17d7a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,6 +617,11 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
   integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
 
+"@types/crypto-js@4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.1.1.tgz#602859584cecc91894eb23a4892f38cfa927890d"
+  integrity sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==
+
 "@types/hoist-non-react-statics@^3.0.1", "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -629,6 +634,11 @@
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
+"@types/node@^20.4.1":
+  version "20.4.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.1.tgz#a6033a8718653c50ac4962977e14d0f984d9527d"
+  integrity sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==
 
 "@types/prop-types@*":
   version "15.7.5"
@@ -997,6 +1007,11 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 csstype@^3.0.10, csstype@^3.0.2:
   version "3.1.2"


### PR DESCRIPTION
### 관련 이슈
- #44

### 수정 사항
- 비밀번호 암호화 함수 생성 => crypto 사용 SHA-256알고리즘, username, secretKey salt값으로 사용
- 로그인 회원가입 회원정보 수정, 비밀번호 검증 컴포넌트에 적용
- 사용자 아이디 쿠키에 저장 (salt 값으로 사용하기 위해 &  이후 navbar에 어차피 띄울예정)
- dotenv 추가하여 .env파일에 VITE_CRYPTO_SECRET_KEY 추가하고  salt 값으로 사용 ( dotenv는 .gitignore에 추가함.)

### 기타 참고 사항
-
